### PR TITLE
[JIRA DDIC-53] add install rule to usr/bin for json-schema-valide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if (BUILD_EXAMPLES)
     target_link_libraries(json-schema-validate json-schema-validator)
 
     install(TARGETS json-schema-validate
-        DESTINATION ${CMAKE_INSTALL_BINDIR})
+        DESTINATION bin)
 
     add_executable(readme-json-schema app/readme.cpp)
     target_link_libraries(readme-json-schema json-schema-validator)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ if (BUILD_EXAMPLES)
     add_executable(json-schema-validate app/json-schema-validate.cpp)
     target_link_libraries(json-schema-validate json-schema-validator)
 
+    install(TARGETS json-schema-validate
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
+
     add_executable(readme-json-schema app/readme.cpp)
     target_link_libraries(readme-json-schema json-schema-validator)
 endif()


### PR DESCRIPTION
@pboettch  ajout de la regle d'installation pour json-schema-validate (utile pour les scripts python de comm BO v2) cf --> https://github.com/STIMIODEV/SIOT10033-sncf-msdi-app/blob/7f8a190c55e45469a2db354bfc485dbaf36d260b/src/comm_bo/msdi-comm-bo-api-rest-json.py#L183

Tu valides ?